### PR TITLE
Availability bug fix

### DIFF
--- a/Bumbodium.Data/Repositories/AvailabilityRepo.cs
+++ b/Bumbodium.Data/Repositories/AvailabilityRepo.cs
@@ -33,10 +33,10 @@ namespace Bumbodium.Data
         public List<Availability> GetAvailabilitiesInRange(DateTime start, DateTime end, string userId)
         {
             return _ctx.Availability.Where(a => 
-            (a.EmployeeId == userId) &&
+            (a.EmployeeId == userId) && (
             (a.StartDateTime > start && a.StartDateTime < end) ||
             (a.EndDateTime > start && a.EndDateTime < end) ||
-            (a.StartDateTime < start && a.EndDateTime > end)
+            (a.StartDateTime < start && a.EndDateTime > end))
             ).ToList();
         }
         public bool AvailabilityExistsInTime(DateTime start, DateTime end, string employeeId)


### PR DESCRIPTION
# Description

Added 2 whole parentheses to fix a bug where the availability view shows availability of every employee

Fixes # (issue)

# How Has This Been Tested?

i created availabilities for 2 different employees and now they only show up for the right employee


# Checklist:

- [x] My code runs
- [x] My code follows the coding guidelines
- [x] I rebased my branch on development
- [x] My code only has comments when necessary for understandability 
- [x] I removed commented out code
- [x] My code corresponds with the documentation
- [x] I have updated the documentation when changes were needed
- [x] All unit-tests succeeded (Except for not implemented exceptions)

# Optional:

- [ ] Is the branch linked to an issue?
